### PR TITLE
update bootstrap dependency to ">=4.3.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -417,7 +417,7 @@
             "dev": true
         },
         "bootstrap": {
-            "version": "4.2.1",
+            "version": ">=4.3.1",
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.2.1.tgz",
             "integrity": "sha512-tt/7vIv3Gm2mnd/WeDx36nfGGHleil0Wg8IeB7eMrVkY0fZ5iTaBisSh8oNANc2IBsCc6vCgCNTIM/IEN0+50Q=="
         },


### PR DESCRIPTION
Hi, Jenny! Following security alert https://github.com/pitt-cdm/website--jlherrle/network/alert/package-lock.json/bootstrap/, I think all we have to do is change this line.